### PR TITLE
This commit got rid of the binding.pry in the

### DIFF
--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Question, type: :model do
         expect(@vote.votable).to be_instance_of(Question)
       end
     end
-
   end
 
 


### PR DESCRIPTION
comment_spec. Dont be alarmed by it not showing
here